### PR TITLE
Fix binds converter to skip PostgreSQL casts

### DIFF
--- a/test/binds_converter/named_test.rb
+++ b/test/binds_converter/named_test.rb
@@ -42,6 +42,11 @@ class BindsConverterNamedTest < Minitest::Test
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name LIKE 'foo:-'", sql
   end
 
+  def test_ignores_postgresql_casts
+    sql = @converter.new("SELECT (data::json ->> 'percent')::float FROM widgets").to_s
+    assert_equal "SELECT (data::json ->> 'percent')::float FROM widgets", sql
+  end
+
   def test_ignores_colon_at_end
     sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name LIKE 'foo:").to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name LIKE 'foo:", sql


### PR DESCRIPTION
https://github.com/jhollinger/occams-record/issues/11

Realization is very similar to https://github.com/rails/rails/blob/7d17add290ffe0f934f0b7656d9234952a99c9dc/activerecord/lib/active_record/sanitization.rb#L213-L225

