### PR TITLE
Raise if not enough bind values are passed to a raw sql statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 1.14.0 (?)
+* Raise `OccamsRecord::MissingBindValuesError` if not enough bind values are passed to `OccamsRecord.sql` (thanks [zverok](https://github.com/jhollinger/occams-record/issues/14)!)
 * Drop support for Ruby 3.0
 
 ### 1.13.0 (2024-12-14)

--- a/lib/occams-record/binds_converter.rb
+++ b/lib/occams-record/binds_converter.rb
@@ -13,8 +13,8 @@ module OccamsRecord
     def self.convert(sql, binds)
       converter =
         case binds
-        when Hash then Named.new(sql)
-        when Array then Positional.new(sql)
+        when Hash then Named.new(sql, binds)
+        when Array then Positional.new(sql, binds)
         else raise ArgumentError, "OccamsRecord: Unsupported SQL bind params '#{binds.inspect}'. Only Hash and Array are supported"
         end
       converter.to_s

--- a/lib/occams-record/binds_converter/abstract.rb
+++ b/lib/occams-record/binds_converter/abstract.rb
@@ -10,21 +10,24 @@ module OccamsRecord
       # @private
       ESCAPE = "\\".freeze
 
-      def initialize(sql, bind_sigil)
+      def initialize(sql, binds, bind_sigil)
         @sql = sql
+        @binds = binds
         @end = sql.size - 1
         @start_i, @i = 0, 0
         @bind_sigil = bind_sigil
+        @found = []
       end
 
       # @return [String] The converted SQL string
       def to_s
         sql = ""
         each { |frag| sql << frag }
+        raise MissingBindValuesError.new(sql, missing_bind_values_msg) if @binds.size < @found.uniq.size
         sql
       end
 
-      protected
+      private
 
       # Yields each SQL fragment and converted bind to the given block
       def each

--- a/lib/occams-record/binds_converter/named.rb
+++ b/lib/occams-record/binds_converter/named.rb
@@ -4,20 +4,31 @@ module OccamsRecord
     # Converts Rails-style named binds (:foo) into native Ruby format (%{foo}).
     #
     class Named
-      def initialize(sql)
+      def initialize(sql, binds)
         @sql = sql
+        @binds = binds
+        @found = []
       end
 
       def to_s
-        @sql.gsub(/([:\\]?):([a-zA-Z]\w*)/) do |match|
+        sql = @sql.gsub(/([:\\]?):([a-zA-Z]\w*)/) do |match|
           if $1 == ":".freeze # skip PostgreSQL casts
             match # return the whole match
           elsif $1 == "\\".freeze # escaped literal colon
             match[1..-1] # return match with escaping backslash char removed
           else
+            @found << $2
             "%{#{$2}}"
           end
         end
+        raise MissingBindValuesError.new(sql, missing_bind_values_msg) if @binds.size < @found.uniq.size
+        sql
+      end
+
+      private
+
+      def missing_bind_values_msg
+        (@found - @binds.keys.map(&:to_s)).join(", ")
       end
     end
   end

--- a/lib/occams-record/binds_converter/positional.rb
+++ b/lib/occams-record/binds_converter/positional.rb
@@ -4,16 +4,21 @@ module OccamsRecord
     # Converts Rails-style positional binds (?) into native Ruby format (%s).
     #
     class Positional < Abstract
-      def initialize(sql)
-        super(sql, "?".freeze)
+      def initialize(sql, binds)
+        super(sql, binds, "?".freeze)
       end
 
-      protected
+      private
 
       def get_bind
         @i += 1
         @start_i = @i
+        @found << @found.size
         "%s".freeze
+      end
+
+      def missing_bind_values_msg
+        (@found.size - @binds.size).to_s
       end
     end
   end

--- a/lib/occams-record/errors.rb
+++ b/lib/occams-record/errors.rb
@@ -1,4 +1,16 @@
 module OccamsRecord
+  # Exception raised when not enough bind values were given
+  class MissingBindValuesError < StandardError
+    def initialize(sql, message)
+      @sql = sql
+      @message = message
+    end
+
+    def to_s = message
+
+    def message = "Missing binds (#{@message}) in #{@sql}"
+  end
+
   # Exception raised when a record wasn't loaded with all requested data
   class MissingDataError < StandardError
     # @return [String]

--- a/lib/occams-record/raw_query.rb
+++ b/lib/occams-record/raw_query.rb
@@ -194,7 +194,7 @@ module OccamsRecord
     end
 
     #
-    # Returns a cursor you can open and perform operations on. A lower-level alternative to 
+    # Returns a cursor you can open and perform operations on. A lower-level alternative to
     # find_each_with_cursor and find_in_batches_with_cursor.
     #
     # NOTE Postgres only. See the docs for OccamsRecord::Cursor for more details.

--- a/test/binds_converter/named_test.rb
+++ b/test/binds_converter/named_test.rb
@@ -13,52 +13,71 @@ class BindsConverterNamedTest < Minitest::Test
   end
 
   def test_no_params
-    sql = @converter.new("SELECT * FROM widgets").to_s
+    sql = @converter.new("SELECT * FROM widgets", {}).to_s
     assert_equal "SELECT * FROM widgets", sql
   end
 
   def test_ruby_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = %{user_id} AND name IN (%{names})").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = %{user_id} AND name IN (%{names})", {user_id: 5, names: %w[A B]}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name IN (%{names})", sql
   end
 
   def test_rails_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name IN (:names)").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name IN (:names)", {user_id: 5, names: %w[A B]}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name IN (%{names})", sql
   end
 
   def test_escapes_rails_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = \\:user_id AND name IN (:names)").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = \\:user_id AND name IN (:names)", {user_id: 5, names: %w[A B]}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = :user_id AND name IN (%{names})", sql
   end
 
   def test_param_at_end
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name = :name").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name = :name", {user_id: 5, name: "A"}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name = %{name}", sql
   end
 
   def test_ignores_colon_followed_by_non_word
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name LIKE 'foo:-'").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name LIKE 'foo:-'", {user_id: 5}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name LIKE 'foo:-'", sql
   end
 
   def test_ignores_postgresql_casts
-    sql = @converter.new("SELECT (data::json ->> 'percent')::float FROM widgets").to_s
+    sql = @converter.new("SELECT (data::json ->> 'percent')::float FROM widgets", {}).to_s
     assert_equal "SELECT (data::json ->> 'percent')::float FROM widgets", sql
   end
 
   def test_ignores_colon_at_end
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name LIKE 'foo:").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name LIKE 'foo:", {user_id: 5}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id} AND name LIKE 'foo:", sql
   end
 
+  def test_missing_binds_raises
+    e = assert_raises OccamsRecord::MissingBindValuesError do
+      @converter.new("SELECT * FROM widgets WHERE user_id = :user_id AND name = :name AND age = :age", {user_id: 5}).to_s
+    end
+    assert_match /Missing binds \(name, age\) in SELECT /, e.message
+  end
+
+  def test_bind_false_positive_raises
+    e = assert_raises OccamsRecord::MissingBindValuesError do
+      @converter.new('SELECT * FROM widgets WHERE user_id = :user_id data @> {"ready":true}', {user_id: 5}).to_s
+    end
+    assert_match /Missing binds \(true\) in SELECT /, e.message
+  end
+
+  def test_too_many_binds_passes
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :user_id", {user_id: 5, age: 42}).to_s
+    assert_equal "SELECT * FROM widgets WHERE user_id = %{user_id}", sql
+  end
+
   def test_stress
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :a:a:a:a:a:a:a:a:a:a:a:a").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :a:a:a:a:a:a:a:a:a:a:a:a", {a: "A"}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{a}%{a}%{a}%{a}%{a}%{a}%{a}%{a}%{a}%{a}%{a}%{a}", sql
   end
 
   def test_stress_with_spaces
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :a:a:a :a:a:a :a:a:a     :a:a:a ").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = :a:a:a :a:a:a :a:a:a     :a:a:a ", {a: "A"}).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %{a}%{a}%{a} %{a}%{a}%{a} %{a}%{a}%{a}     %{a}%{a}%{a} ", sql
   end
 end

--- a/test/binds_converter/positional_test.rb
+++ b/test/binds_converter/positional_test.rb
@@ -13,37 +13,49 @@ class BindsConverterPositionalTest < Minitest::Test
   end
 
   def test_no_params
-    sql = @converter.new("SELECT * FROM widgets").to_s
+    sql = @converter.new("SELECT * FROM widgets", []).to_s
     assert_equal "SELECT * FROM widgets", sql
   end
 
   def test_ruby_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = %s AND name IN (%s)").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = %s AND name IN (%s)", [5, %w[foo bar]]).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %s AND name IN (%s)", sql
   end
 
   def test_rails_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name IN (?)").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name IN (?)", [5, %w[foo bar]]).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %s AND name IN (%s)", sql
   end
 
   def test_escapes_rails_params
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = \\? AND name IN (?)").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = \\? AND name IN (?)", [5, %w[foo bar]]).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = ? AND name IN (%s)", sql
   end
 
   def test_param_at_end
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name = ?").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name = ?", [5, "foo"]).to_s
+    assert_equal "SELECT * FROM widgets WHERE user_id = %s AND name = %s", sql
+  end
+
+  def test_missing_binds_raises
+    e = assert_raises OccamsRecord::MissingBindValuesError do
+      @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name = ?", [5]).to_s
+    end
+    assert_match /Missing binds \(1\) in SELECT /, e.message
+  end
+
+  def test_too_many_binds_passes
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ? AND name = ?", [5, "foo", "bar"]).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %s AND name = %s", sql
   end
 
   def test_stress
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ????????????").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ????????????", [5] * 12).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %s%s%s%s%s%s%s%s%s%s%s%s", sql
   end
 
   def test_stress_with_spaces
-    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ??? ??? ???     ??? ").to_s
+    sql = @converter.new("SELECT * FROM widgets WHERE user_id = ??? ??? ???     ??? ", [5] * 12).to_s
     assert_equal "SELECT * FROM widgets WHERE user_id = %s%s%s %s%s%s %s%s%s     %s%s%s ", sql
   end
 end


### PR DESCRIPTION
Raises `OccamsRecord::MissingBindValuesError` if not enough bind values are passed in. #14 

```ruby
res = OccamsRecord.
  sql("SELECT * FROM widgets WHERE user_id = :user_id AND name = :name AND age = :age", {user_id: 5}).
  run

# OccamsRecord::MissingBindValuesError: Missing binds (name, age) in SELECT * FROM widgets WHERE user_id = %{user_id} AND name = %{name} AND age = %{age}
```

Positional binds will show the number of missing binds:

```ruby
res = OccamsRecord.
  sql("SELECT * FROM widgets WHERE user_id = ? AND name = ? AND age = ?", [5]).
  run

# OccamsRecord::MissingBindValuesError: Missing binds (2) in SELECT * FROM widgets WHERE user_id = %s AND name = %s AND age = %s
```